### PR TITLE
Drop python 3.6 from the black configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,6 @@ repos:
     rev: 21.9b0
     hooks:
       - id: black
-        language_version: python3.6
   - repo: 'https://github.com/PyCQA/flake8'
     rev: 3.9.2
     hooks:


### PR DESCRIPTION
Thank you for the pre-commit hook, I'm going to use it :) 

This PR permit for black to work on other interpreter than python 3.6 (which is end of life since December).