### PR TITLE
pre-commit: Remove mypy: additional_dependencies: - types-all

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,8 +41,6 @@ repos:
       - id: mypy
         args:
           - '--config-file=.codestyle/.mypy.ini'
-        additional_dependencies:
-          - types-all
   - repo: 'https://github.com/PyCQA/bandit'
     rev: 1.7.0
     hooks:


### PR DESCRIPTION
https://github.com/asottile-archive/types-all is Deprecated and Archived.

Its use is blocking:
* #6